### PR TITLE
add Dockerfile, static Makefile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine AS build
+WORKDIR $GOPATH/src/github.com/lukechampine/walrus
+COPY . .
+ENV CGO_ENABLED=0
+RUN apk -U --no-cache add bash upx git gcc make \
+    && make static \
+    && upx /go/bin/walrus
+
+FROM scratch
+COPY --from=build /go/bin/walrus /walrus
+COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+CMD ["/walrus"]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ ldflags = -X 'main.githash=`git rev-parse --short HEAD`' \
 all:
 	go install -ldflags "$(ldflags)" ./cmd/...
 
+# static is like all, but for static binaries
+static:
+	go install -ldflags "$(ldflags) -s -w -extldflags='-static'" -tags='timetzdata' ./cmd/...
+
 # dev builds a binary with dev constants
 dev:
 	go install -ldflags "$(ldflags)" -tags='dev' ./cmd/...
@@ -35,4 +39,4 @@ lint:
 		--skip-dirs=internal \
 		./...
 
-.PHONY: all dev test test-long bench lint
+.PHONY: all static dev test test-long bench lint


### PR DESCRIPTION
Small container image, ~3.5M.

The static build target includes the necessary static flags, plus timetzdata (no need to copy ZONEINFO into `scratch`).